### PR TITLE
use aquamarine 0.1 branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,5 @@ serde_json = "1.0.45"
 fancy-regex = "0.5.0"
 crossbeam = "0.8.0"
 threadpool = "1.8.1"
-aquamarine = "0.1.5"
+aquamarine = "0.1"
 


### PR DESCRIPTION
Aquamarine has been updated to support offline mode in 0.1.8, and doesn't require internet connection to build and view the rendered diagrams anymore.

This change switches from pinned patch version to a the 0.1 branch in order to include the offline more feature and other backward-compatible improvements coming in future